### PR TITLE
Use item id instead of resolved item id to identify Pocket articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ from https://docs.docker.com/get-docker/. Then run the following command to star
 have not tested it on Windows yet):
 
 ```
-touch ~/.remarkable-pocket ~/.rmapi && mkdir -p ~/.rmapi-cache && docker run -it --env TZ=Europe/Amsterdam -p 65112:65112 -v ~/.remarkable-pocket:/root/.remarkable-pocket -v ~/.rmapi:/root/.rmapi -v ~/.rmapi-cache:/root/.cache/rmapi ghcr.io/nov1n/remarkable-pocket:0.2.0
+touch ~/.remarkable-pocket ~/.rmapi && mkdir -p ~/.rmapi-cache && docker run -it --env TZ=Europe/Amsterdam -p 65112:65112 -v ~/.remarkable-pocket:/root/.remarkable-pocket -v ~/.rmapi:/root/.rmapi -v ~/.rmapi-cache:/root/.cache/rmapi ghcr.io/nov1n/remarkable-pocket:0.2.1
 ```
 
 The first time you run the application, you will be asked to authorize Pocket and Remarkable Cloud. Once you have done

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "nl.carosi"
-version = "0.2.0"
+version = "0.2.1"
 
 java {
     toolchain {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   remarkable-pocket:
-    image: ghcr.io/nov1n/remarkable-pocket:0.2.0
+    image: ghcr.io/nov1n/remarkable-pocket:0.2.1
     restart: always
     ports:
       - 65112:65112

--- a/nl.carosi.remarkable-pocket.plist
+++ b/nl.carosi.remarkable-pocket.plist
@@ -8,7 +8,7 @@
     <array>
        <string>/bin/sh</string>
        <string>-c</string>
-       <string>while ! /usr/local/bin/docker version > /dev/null 2>&amp;1; do sleep 5; done &amp;&amp; /usr/local/bin/docker run --env TZ=Europe/Amsterdam -v ~/.remarkable-pocket:/root/.remarkable-pocket -v ~/.rmapi:/root/.rmapi -v ~/.rmapi-cache:/root/.cache/rmapi ghcr.io/nov1n/remarkable-pocket:0.2.0 1>>$HOME/.remarkable-pocket.log 2>&amp;1</string>
+       <string>while ! /usr/local/bin/docker version > /dev/null 2>&amp;1; do sleep 5; done &amp;&amp; /usr/local/bin/docker run --env TZ=Europe/Amsterdam -v ~/.remarkable-pocket:/root/.remarkable-pocket -v ~/.rmapi:/root/.rmapi -v ~/.rmapi-cache:/root/.cache/rmapi ghcr.io/nov1n/remarkable-pocket:0.2.1 1>>$HOME/.remarkable-pocket.log 2>&amp;1</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/src/main/java/nl/carosi/remarkablepocket/PocketService.java
+++ b/src/main/java/nl/carosi/remarkablepocket/PocketService.java
@@ -40,7 +40,7 @@ final class PocketService {
                         .build();
         List<PocketItem> unreads = pocket.getItems(cmd).getList();
         return unreads.stream()
-                .map(e -> Article.of(e.getResolvedId(), e.getResolvedUrl(), e.getResolvedTitle()))
+                .map(e -> Article.of(e.getItemId(), e.getResolvedUrl(), e.getResolvedTitle()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/nl/carosi/remarkablepocket/SyncCommand.java
+++ b/src/main/java/nl/carosi/remarkablepocket/SyncCommand.java
@@ -19,7 +19,7 @@ import picocli.CommandLine.Option;
         sortOptions = false,
         usageHelpAutoWidth = true,
         // TODO: Read from gradle.properties
-        version = "0.2.0",
+        version = "0.2.1",
         mixinStandardHelpOptions = true)
 class SyncCommand implements Callable<Integer> {
     @Option(


### PR DESCRIPTION
In some cases the two are different and even though the archive call to Pocket will succeed, the article is not actually archived.