### PR TITLE
Fix 'null' article name in sync

### DIFF
--- a/src/main/java/nl/carosi/remarkablepocket/model/Document.java
+++ b/src/main/java/nl/carosi/remarkablepocket/model/Document.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Document(
-    @JsonProperty("CurrentPage") int currentPage, @JsonProperty("VissibleName") String name) {}
+public record Document(@JsonProperty("CurrentPage") int currentPage, @JsonProperty("Name") String name) {
+}


### PR DESCRIPTION
Fix [Issue #33](https://github.com/nov1n/RemarkablePocket/issues/33)